### PR TITLE
docs: add CLAUDE.md and expand README documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [README.md](README.md) for project overview, setup instructions, and architecture documentation.
+
+## Language Migration Status
+
+The codebase has migrated from Ruby to Python:
+- **Python** (`member_csv.py`): Current production version - make changes here
+- **Ruby** (`member_csv.rb`): Deprecated, kept for reference only
+- **Ruby** (`generate_payment_links.rb`): Still active (no Python equivalent yet)
+
+When making changes, modify Python scripts unless specifically working on Ruby code.
+
+## Hardcoded Values
+
+Update these values when modifying scripts:
+
+**Subscription Ignore List** (`member_csv.py:30-36`):
+```python
+ignore_subscriptions = {
+    "sub_1LBOHNG9vhwQIFDDfUpz7HSM",
+    "sub_1LBOOAG9vhwQIFDDy9msWx4R",
+    "sub_1KbZHMG9vhwQIFDD9sXK0tIi",
+    "sub_1KcC9OG9vhwQIFDDHkGiH3S7",
+    "sub_1LcZIUG9vhwQIFDDkmzqx39N"
+}
+```
+
+**Google Spreadsheet ID** (`member_csv.py:185`):
+```python
+spreadsheet_id = "1xmZL8_d8yAv8qjSJjdQri6Z74Sn8PQkr9hSNcmRdMNg"
+```
+
+**Stripe Price IDs** (`generate_payment_links.rb:8-22`): Production price objects (test IDs commented out on lines 24-38)
+
+## Implementation Notes
+
+- **Timezone**: All dates use `America/Chicago` - use `pytz` for conversions
+- **Mailchimp Member ID**: MD5 hash of lowercase email (`hashlib.md5(email.lower().encode()).hexdigest()`)
+- **One-Time Donations**: Only InvoiceItems with description exactly matching "One-Time Donation" are counted
+- **No Cleanup**: Script does NOT remove expired members or "Member" tags from Mailchimp
+- **Duplicate Handling**: Multiple subscriptions per customer results in duplicate API calls; only latest status persists

--- a/README.md
+++ b/README.md
@@ -1,4 +1,135 @@
-Stripe Scripts
-==============
+# Stripe Scripts
 
-The Illinois Shuffleboard Association uses [Stripe](https://stripe.com/) to handle payment processing. These are a series of scripts we use to automate some of our processes.
+Automation scripts for the Illinois Shuffleboard Association (ILSA) to manage membership payments, subscriptions, and mailing lists through Stripe, Mailchimp, and Google Sheets.
+
+## Scripts
+
+| Script | Language | Purpose |
+|--------|----------|---------|
+| `member_csv.py` | Python | **Primary** - Syncs Stripe subscriptions to Mailchimp and Google Sheets |
+| `generate_payment_links.rb` | Ruby | Generates Stripe payment links for membership + donation combinations |
+| `member_csv.rb` | Ruby | Legacy version of member_csv.py (deprecated) |
+
+## Setup
+
+### Prerequisites
+
+- Python 3.x (for `member_csv.py`)
+- Ruby 3.1.2 (for Ruby scripts)
+
+### Install Dependencies
+
+```bash
+# Python
+pip install -r requirements.txt
+
+# Ruby
+bundle install
+```
+
+### Environment Variables
+
+Create a `.env` file based on `.env.example`:
+
+```
+STRIPE_SECRET_KEY=          # Stripe API secret key
+MAILCHIMP_API_KEY=          # Mailchimp API key
+MAILCHIMP_SERVER_PREFIX=    # Mailchimp server prefix (e.g., "us10")
+MAILCHIMP_LIST_ID=          # Mailchimp list/audience ID
+```
+
+### Google Service Account
+
+For Google Sheets integration:
+
+1. Create a service account following [gspread documentation](https://docs.gspread.org/en/latest/oauth2.html#for-bots-using-service-account)
+2. Save credentials as `.google_credentials.json` (use `.google_credentials.json.example` as template)
+3. Grant the service account email **Editor** access to the target Google Sheet
+
+## Usage
+
+### Member CSV & Sync
+
+```bash
+python member_csv.py
+```
+
+This script:
+1. Fetches all Stripe subscriptions (active and inactive)
+2. Syncs members with Mailchimp (adds subscribers, updates tags)
+3. Generates `output/members.csv`
+4. Updates Google Sheets with backup rotation
+
+### Generate Payment Links
+
+```bash
+ruby generate_payment_links.rb
+```
+
+Creates Stripe payment links combining:
+- Base membership price
+- Optional donation tiers ($5, $10, $25, $50, $100, $250, $500, $1000)
+- Optional league fee
+
+Outputs JSON with URLs for all combinations.
+
+## Architecture
+
+### Member CSV Workflow
+
+```
+Stripe API ──► member_csv.py ──┬──► Mailchimp (sync members/tags)
+                               ├──► output/members.csv
+                               └──► Google Sheets (current + backup)
+```
+
+**Stripe Data Extracted:**
+- Subscriptions (all statuses)
+- Customer info (name, email, address)
+- One-time donations (InvoiceItems with description "One-Time Donation")
+
+**Mailchimp Sync:**
+- New members added with merge fields: `FNAME`, `LNAME`, `SUB_STATUS`
+- Existing members: `SUB_STATUS` field updated
+- Active subscriptions: "Member" tag applied
+- Does NOT remove expired members or tags (manual cleanup required)
+
+**Google Sheets:**
+- Deletes "members - backup" sheet
+- Renames "members - current" to "members - backup"
+- Creates new "members - current" with latest data
+- Applies formatting (frozen headers, auto-sized columns)
+
+### CSV Output Format
+
+| Column | Description |
+|--------|-------------|
+| # | Sequential counter (active members only) |
+| Name | Customer full name |
+| Email | Customer email |
+| City, State | From address or shipping address |
+| Member Status | Subscription status (active, canceled, etc.) |
+| Member Since | Subscription start date |
+| Subscription End | End date or current period end |
+| Donations | Total one-time donations |
+| Mailing List | Mailchimp subscription status |
+| Collection Method | charge_automatically or send_invoice |
+| Stripe ID | Subscription ID |
+
+## Common Issues
+
+1. **Google Sheets Permission Error**: Ensure service account email has Editor access *before* running
+2. **Mailchimp Rate Limits**: Large member counts may hit API limits (sequential processing)
+3. **Timezone**: All dates use America/Chicago timezone
+4. **Duplicate Processing**: Multiple subscriptions per customer = multiple API calls (last status wins)
+5. **One-Time Donations**: Only counted if InvoiceItem description exactly matches "One-Time Donation"
+
+## Configuration
+
+### Mailchimp Merge Fields
+
+Custom merge fields configured at: https://us10.admin.mailchimp.com/audience/merge-fields/?id=337185
+
+- `FNAME` - First name
+- `LNAME` - Last name
+- `SUB_STATUS` - Stripe subscription status


### PR DESCRIPTION
## Summary

- Added `CLAUDE.md` with agent-specific guidance for Claude Code (language migration status, hardcoded values, implementation notes)
- Expanded `README.md` from 4 lines to comprehensive documentation covering setup, usage, architecture, and troubleshooting

## Changes

**CLAUDE.md** (new file):
- References README for shared content
- Documents which scripts to modify (Python vs Ruby)
- Lists hardcoded values with line numbers
- Implementation notes for code changes

**README.md** (expanded):
- Scripts overview table
- Setup instructions (dependencies, env vars, Google credentials)
- Usage examples for both scripts
- Architecture diagram and workflow
- CSV output format table
- Common issues section

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md provides useful context for Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)