### PR TITLE
ci: add GitHub Actions workflow for automated member sync

### DIFF
--- a/.github/workflows/sync-members.yml
+++ b/.github/workflows/sync-members.yml
@@ -2,7 +2,7 @@ name: Sync ILSA Members
 
 on:
   schedule:
-    - cron: '0 14 * * 1'  # Weekly Monday 8am Central (UTC-6)
+    - cron: '0 14 * * *'  # Daily 8am Central (UTC-6)
   workflow_dispatch:        # Manual trigger button
 
 jobs:

--- a/.github/workflows/sync-members.yml
+++ b/.github/workflows/sync-members.yml
@@ -1,0 +1,39 @@
+name: Sync ILSA Members
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Weekly Monday 8am Central (UTC-6)
+  workflow_dispatch:        # Manual trigger button
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Write Google credentials
+        run: echo '${{ secrets.GOOGLE_CREDENTIALS }}' > .google_credentials.json
+
+      - name: Run member sync
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
+          MAILCHIMP_SERVER_PREFIX: ${{ secrets.MAILCHIMP_SERVER_PREFIX }}
+          MAILCHIMP_LIST_ID: ${{ secrets.MAILCHIMP_LIST_ID }}
+        run: python member_csv.py
+
+      - name: Upload CSV artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: members-csv
+          path: output/members.csv
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Configure repository secrets at **Settings > Secrets and variables > Actions**:
 | `MAILCHIMP_LIST_ID` | Mailchimp list/audience ID |
 | `GOOGLE_CREDENTIALS` | Entire contents of `.google_credentials.json` |
 
-The workflow runs automatically every Monday at 8am Central, or can be triggered manually from the Actions tab.
+The workflow runs automatically daily at 8am Central, or can be triggered manually from the Actions tab.
 
 ## Usage
 
 ### Member CSV & Sync
 
-**Automated (Recommended):** Runs automatically every Monday at 8am Central via GitHub Actions.
+**Automated (Recommended):** Runs automatically daily at 8am Central via GitHub Actions.
 
 - **Manual trigger:** Go to [Actions](https://github.com/IllinoisShuffle/stripe-scripts/actions) > "Sync ILSA Members" > "Run workflow"
 - **View results:** Check workflow run for logs; CSV artifact available for download (7-day retention)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,158 @@
-Stripe Scripts
-==============
+# Stripe Scripts
 
-The Illinois Shuffleboard Association uses [Stripe](https://stripe.com/) to handle payment processing. These are a series of scripts we use to automate some of our processes.
+[![Sync ILSA Members](https://github.com/IllinoisShuffle/stripe-scripts/actions/workflows/sync-members.yml/badge.svg)](https://github.com/IllinoisShuffle/stripe-scripts/actions/workflows/sync-members.yml)
+
+Automation scripts for the Illinois Shuffleboard Association (ILSA) to manage membership payments, subscriptions, and mailing lists through Stripe, Mailchimp, and Google Sheets.
+
+## Scripts
+
+| Script | Language | Purpose |
+|--------|----------|---------|
+| `member_csv.py` | Python | **Primary** - Syncs Stripe subscriptions to Mailchimp and Google Sheets |
+| `generate_payment_links.rb` | Ruby | Generates Stripe payment links for membership + donation combinations |
+| `member_csv.rb` | Ruby | Legacy version of member_csv.py (deprecated) |
+
+## Setup
+
+### Prerequisites
+
+- Python 3.x (for `member_csv.py`)
+- Ruby 3.1.2 (for Ruby scripts)
+
+### Install Dependencies
+
+```bash
+# Python
+pip install -r requirements.txt
+
+# Ruby
+bundle install
+```
+
+### Environment Variables
+
+Create a `.env` file based on `.env.example`:
+
+```
+STRIPE_SECRET_KEY=          # Stripe API secret key
+MAILCHIMP_API_KEY=          # Mailchimp API key
+MAILCHIMP_SERVER_PREFIX=    # Mailchimp server prefix (e.g., "us10")
+MAILCHIMP_LIST_ID=          # Mailchimp list/audience ID
+```
+
+### Google Service Account
+
+For Google Sheets integration:
+
+1. Create a service account following [gspread documentation](https://docs.gspread.org/en/latest/oauth2.html#for-bots-using-service-account)
+2. Save credentials as `.google_credentials.json` (use `.google_credentials.json.example` as template)
+3. Grant the service account email **Editor** access to the target Google Sheet
+
+### GitHub Actions (Automated Sync)
+
+Configure repository secrets at **Settings > Secrets and variables > Actions**:
+
+| Secret Name | Description |
+|-------------|-------------|
+| `STRIPE_SECRET_KEY` | Stripe API secret key |
+| `MAILCHIMP_API_KEY` | Mailchimp API key |
+| `MAILCHIMP_SERVER_PREFIX` | Mailchimp server prefix (e.g., "us10") |
+| `MAILCHIMP_LIST_ID` | Mailchimp list/audience ID |
+| `GOOGLE_CREDENTIALS` | Entire contents of `.google_credentials.json` |
+
+The workflow runs automatically every Monday at 8am Central, or can be triggered manually from the Actions tab.
+
+## Usage
+
+### Member CSV & Sync
+
+**Automated (Recommended):** Runs automatically every Monday at 8am Central via GitHub Actions.
+
+- **Manual trigger:** Go to [Actions](https://github.com/IllinoisShuffle/stripe-scripts/actions) > "Sync ILSA Members" > "Run workflow"
+- **View results:** Check workflow run for logs; CSV artifact available for download (7-day retention)
+
+**Local execution:**
+
+```bash
+python member_csv.py
+```
+
+This script:
+1. Fetches all Stripe subscriptions (active and inactive)
+2. Syncs members with Mailchimp (adds subscribers, updates tags)
+3. Generates `output/members.csv`
+4. Updates Google Sheets with backup rotation
+
+### Generate Payment Links
+
+```bash
+ruby generate_payment_links.rb
+```
+
+Creates Stripe payment links combining:
+- Base membership price
+- Optional donation tiers ($5, $10, $25, $50, $100, $250, $500, $1000)
+- Optional league fee
+
+Outputs JSON with URLs for all combinations.
+
+## Architecture
+
+### Member CSV Workflow
+
+```
+Stripe API ──► member_csv.py ──┬──► Mailchimp (sync members/tags)
+                               ├──► output/members.csv
+                               └──► Google Sheets (current + backup)
+```
+
+**Stripe Data Extracted:**
+- Subscriptions (all statuses)
+- Customer info (name, email, address)
+- One-time donations (InvoiceItems with description "One-Time Donation")
+
+**Mailchimp Sync:**
+- New members added with merge fields: `FNAME`, `LNAME`, `SUB_STATUS`
+- Existing members: `SUB_STATUS` field updated
+- Active subscriptions: "Member" tag applied
+- Does NOT remove expired members or tags (manual cleanup required)
+
+**Google Sheets:**
+- Deletes "members - backup" sheet
+- Renames "members - current" to "members - backup"
+- Creates new "members - current" with latest data
+- Applies formatting (frozen headers, auto-sized columns)
+
+### CSV Output Format
+
+| Column | Description |
+|--------|-------------|
+| # | Sequential counter (active members only) |
+| Name | Customer full name |
+| Email | Customer email |
+| City, State | From address or shipping address |
+| Member Status | Subscription status (active, canceled, etc.) |
+| Member Since | Subscription start date |
+| Subscription End | End date or current period end |
+| Donations | Total one-time donations |
+| Mailing List | Mailchimp subscription status |
+| Collection Method | charge_automatically or send_invoice |
+| Stripe ID | Subscription ID |
+
+## Common Issues
+
+1. **Google Sheets Permission Error**: Ensure service account email has Editor access *before* running
+2. **Mailchimp Rate Limits**: Large member counts may hit API limits (sequential processing)
+3. **Timezone**: All dates use America/Chicago timezone
+4. **Duplicate Processing**: Multiple subscriptions per customer = multiple API calls (last status wins)
+5. **One-Time Donations**: Only counted if InvoiceItem description exactly matches "One-Time Donation"
+
+## Configuration
+
+### Mailchimp Merge Fields
+
+Custom merge fields configured at: https://us10.admin.mailchimp.com/audience/merge-fields/?id=337185
+
+- `FNAME` - First name
+- `LNAME` - Last name
+- `SUB_STATUS` - Stripe subscription status


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automate weekly member sync (Monday 8am Central)
- Expand README with comprehensive documentation (setup, architecture, troubleshooting)
- Workflow uploads CSV output as downloadable artifact (7-day retention)

## Changes

**New file:** `.github/workflows/sync-members.yml`
- Scheduled cron trigger: `0 14 * * 1` (Monday 8am Central / 2pm UTC)
- Manual `workflow_dispatch` trigger for on-demand runs
- Python 3.11 with pip caching for faster execution
- Uploads `output/members.csv` as artifact

**Updated:** `README.md`
- Added workflow status badge
- New "GitHub Actions (Automated Sync)" setup section with secrets table
- Updated usage section to highlight automated execution

## Required Secrets

Configure these in **Settings > Secrets and variables > Actions** before running:

| Secret | Source |
|--------|--------|
| `STRIPE_SECRET_KEY` | Current `.env` file |
| `MAILCHIMP_API_KEY` | Current `.env` file |
| `MAILCHIMP_SERVER_PREFIX` | Current `.env` file |
| `MAILCHIMP_LIST_ID` | Current `.env` file |
| `GOOGLE_CREDENTIALS` | Contents of `.google_credentials.json` |

## Test plan

- [ ] Configure repository secrets
- [ ] Manually trigger workflow from Actions tab
- [ ] Verify workflow completes successfully
- [ ] Confirm Google Sheet is updated with current data
- [ ] Verify CSV artifact is downloadable

🤖 Generated with [Claude Code](https://claude.com/claude-code)